### PR TITLE
Added new controls for Bomberman World

### DIFF
--- a/mame139/bbmanw.cfg
+++ b/mame139/bbmanw.cfg
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0"?>
+<!-- This set of controls by contributed by Matt Brine -->
+<mameconfig version="10">
+    <system name="bbmanw">
+        <input>
+            <port tag="SYSTEM" type="START1" mask="1" defvalue="1">
+                <newseq type="standard">
+                    JOYCODE_1_BUTTON8
+                </newseq>
+            </port>
+            <port tag="SYSTEM" type="START2" mask="2" defvalue="2">
+                <newseq type="standard">
+                    JOYCODE_2_BUTTON8
+                </newseq>
+            </port>
+            <port tag="SYSTEM" type="COIN1" mask="4" defvalue="4">
+                <newseq type="standard">
+                    JOYCODE_1_BUTTON8
+                </newseq>
+            </port>
+            <port tag="SYSTEM" type="COIN2" mask="8" defvalue="8">
+                <newseq type="standard">
+                    JOYCODE_2_BUTTON8
+                </newseq>
+            </port>
+        </input>
+    </system>
+</mameconfig>

--- a/mame139/bbmanw.cfg
+++ b/mame139/bbmanw.cfg
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0"?>
-<!-- This set of controls by contributed by Matt Brine -->
+<!-- This set of controls was contributed by Matt Brine -->
 <mameconfig version="10">
     <system name="bbmanw">
         <input>


### PR DESCRIPTION
This corrects the issue where Player 2 could not add any credits.  Now the 2P START button adds credits for Player 2 instead.